### PR TITLE
Enable Voice Notify to request audio focus when speaking

### DIFF
--- a/res/values/donottranslate.xml
+++ b/res/values/donottranslate.xml
@@ -25,4 +25,5 @@
 	<string name="key_test">test</string>
 	<string name="key_notify_log">notify_log</string>
 	<string name="key_support">support</string>
+	<string name="key_audio_focus">audio_focus</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -74,6 +74,8 @@
 	<string name="test_summary">Post a notification (delayed 5 seconds) to test current settings.</string>
 	<string name="test_ignored">Voice Notify is ignored in App List.\nTest will run, but notification will not be spoken.</string>
 	<string name="support_summary">Donate, rate/comment, or contact the developer with problems or suggestions.</string>
+    <string name="audio_focus">Pause/dim media</string>
+    <string name="audio_focus_summary">Request other media to pause/dim when speaking</string>
 	
 	<!-- MainActivity.java and xml/preferences.xml -->
 	<string name="test">Test</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -56,6 +56,10 @@
 		android:key="@string/key_toasts"
 		android:title="@string/speak_toasts"
 		android:summary="@string/speak_toasts_summary" />
+    <CheckBoxPreference
+        android:key="@string/key_audio_focus"
+        android:title="@string/audio_focus"
+        android:summary="@string/audio_focus_summary" />
 	<EditTextPreference
 		android:key="@string/key_shake_threshold"
 		android:title="@string/shake_to_silence"


### PR DESCRIPTION
Hi, I'm a huge fan of Voice Notify, it's one of the main reasons I switched from iOS to Android.  However, a lot of the music I listen to is very loud, so it overpowers the spoken notifications.  Because of this, I added an ability to Voice Notify to allow it to request Audio Focus from the OS.  This means the OS will automatically pause/dim currently playing media while Voice Notify is speaking, and automatically resume playing when it's done.  I've made this behavior an option in the preferences pane, and tested it on my own phone, it works just fine.

Thanks,
-Scott-
