### PR TITLE
Adopting alternate headset detection method if available

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -23,6 +23,7 @@
 		android:targetSdkVersion="8"/>
 	<uses-permission android:name="android.permission.BLUETOOTH"/>
 	<uses-permission android:name="android.permission.VIBRATE"/>
+	<uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 	<uses-feature
 		android:name="android.hardware.touchscreen"
 		android:required="false"/>

--- a/src/com/pilot51/voicenotify/Service.java
+++ b/src/com/pilot51/voicenotify/Service.java
@@ -35,6 +35,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.media.AudioManager;
+import android.media.AudioTrack;
 import android.os.Build;
 import android.os.Handler;
 import android.os.PowerManager;
@@ -290,10 +291,10 @@ public class Service extends AccessibilityService {
 		if (isScreenOn() && !Common.getPrefs(this).getBoolean(Common.KEY_SPEAK_SCREEN_ON, true)) {
 			ignoreReasons.add(getString(R.string.reason_screen_on));
 		}
-		if (!(isHeadsetPlugged || isBluetoothConnected) && !Common.getPrefs(this).getBoolean(Common.KEY_SPEAK_HEADSET_OFF, true)) {
+		if (!isHeadsetOn() && !Common.getPrefs(this).getBoolean(Common.KEY_SPEAK_HEADSET_OFF, true)) {
 			ignoreReasons.add(getString(R.string.reason_headset_off));
 		}
-		if ((isHeadsetPlugged || isBluetoothConnected) && !Common.getPrefs(this).getBoolean(Common.KEY_SPEAK_HEADSET_ON, true)) {
+		if (isHeadsetOn() && !Common.getPrefs(this).getBoolean(Common.KEY_SPEAK_HEADSET_ON, true)) {
 			ignoreReasons.add(getString(R.string.reason_headset_on));
 		}
 		if (!ignoreReasons.isEmpty()) {
@@ -432,6 +433,17 @@ public class Service extends AccessibilityService {
 			isScreenOn = CheckScreen.isScreenOn(this);
 		}
 		return isScreenOn;
+	}
+
+	@SuppressLint("NewApi")
+	private boolean isHeadsetOn() {
+		if (Build.VERSION.SDK_INT >= 5) {
+			return (audioMan.isBluetoothA2dpOn() || audioMan.isWiredHeadsetOn());
+		}
+		else
+		{
+			return (isHeadsetPlugged || isBluetoothConnected);
+		}
 	}
 
 	@SuppressLint("NewApi")


### PR DESCRIPTION
Now using AudioManager's methods to detect presence of headset if API
level sufficient - isBluetoothA2dpOn() and isWiredHeadsetOn(). These are marked as
deprecated in the Android API documents, but is suggested for use by
Google's own docs (http://developer.android.com/training/managing-audio/audio-output.html).

Manifest modified to add the permission MODIFY_AUDIO_SETTINGS which is
required for isWiredHeadsetOn() to work properly.
