### PR TITLE
Allow the user to choose to pause, dim, or neither, on speaking

### DIFF
--- a/res/values/donottranslate.xml
+++ b/res/values/donottranslate.xml
@@ -13,7 +13,13 @@
 		<item>2</item>
 		<item>4</item>
 	</string-array>
-	
+
+    <string-array name="audio_focus_value">
+        <item>0</item>
+        <item>2</item>
+        <item>3</item>
+    </string-array>
+
 	<!-- Preference keys -->
 	<string name="key_status">status</string>
 	<string name="key_appList">appList</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -82,6 +82,11 @@
 	<string name="support_summary">Donate, rate/comment, translations, source code, or contact the developer.</string>
 	<string name="audio_focus">Pause/dim media</string>
 	<string name="audio_focus_summary">Request other media to pause/dim when speaking</string>
+    <string-array name="audio_focus_name">
+        <item>None</item>
+        <item>Pause</item>
+        <item>Dim</item>
+    </string-array>
 	
 	<!-- MainActivity.java and xml/preferences.xml -->
 	<string name="test">Test</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -55,12 +55,14 @@
 		android:key="@string/key_toasts"
 		android:title="@string/speak_toasts"
 		android:summary="@string/speak_toasts_summary" />
-	<CheckBoxPreference
+	<ListPreference
 		android:key="@string/key_audio_focus"
 		android:title="@string/audio_focus"
 		android:summary="@string/audio_focus_summary"
-		android:defaultValue="true" />
-	<EditTextPreference
+        android:entries="@array/audio_focus_name"
+        android:entryValues="@array/audio_focus_value"
+		android:defaultValue="0" />
+    <EditTextPreference
 		android:key="@string/key_shake_threshold"
 		android:title="@string/shake_to_silence"
 		android:summary="@string/shake_to_silence_summary"


### PR DESCRIPTION
So, spotify recently decided to actually respond to dim requests, however, it does so in a pretty terrible manner, making both the music and the notification too quiet to hear.  This option to choose pause vs dim allows you to put it back the way it was.
