### PR TITLE
Add option to ignore groups or not

### DIFF
--- a/app/src/main/java/com/pilot51/voicenotify/Service.java
+++ b/app/src/main/java/com/pilot51/voicenotify/Service.java
@@ -143,7 +143,8 @@ public class Service extends NotificationListenerService {
 	@Override
 	public void onNotificationPosted(StatusBarNotification sbn) {
 		Notification notification = sbn.getNotification();
-		if ((notification.flags & Notification.FLAG_GROUP_SUMMARY) != 0) {
+		if (prefs.getBoolean(getString(R.string.key_ignore_groups), true)
+				&& ((notification.flags & Notification.FLAG_GROUP_SUMMARY) != 0)) {
 			return; // Completely ignore group summary notifications.
 		}
 		App app = AppListActivity.findOrAddApp(sbn.getPackageName(), this);

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -27,6 +27,7 @@
 	<string name="key_shake_threshold">shake_threshold</string>
 	<string name="key_ignore_strings">ignore_strings</string>
 	<string name="key_ignore_empty">ignore_empty</string>
+	<string name="key_ignore_groups">ignore_groups</string>
 	<string name="key_ignore_repeat">ignore_repeat</string>
 	<string name="key_max_length">key_max_length</string>
 	<string name="key_device_state">device_state</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,9 @@
 	<string name="ignore_empty">Ignore Empty</string>
 	<string name="ignore_empty_summary_on">Notifications without a message will not be spoken</string>
 	<string name="ignore_empty_summary_off">Notifications without a message will be spoken as \"Notification from [app name].\"</string>
+	<string name="ignore_groups">Ignore Group Messages</string>
+	<string name="ignore_groups_summary_on">Notifications containing multiple messages will not be spoken</string>
+	<string name="ignore_groups_summary_off">Notifications containing multiple messages will be spoken</string>
 	<string name="ignore_repeat">Ignore Repeats</string>
 	<string name="ignore_repeat_summary">Ignore subsequent identical notifications within a set time</string>
 	<string name="ignore_repeat_dialog_msg">Set number of seconds that must pass since last notification before a repeat can be spoken.\nIgnored repeats reset the count and different notifications clear it.\nBlank = infinite.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -92,6 +92,12 @@
 		android:summaryOn="@string/ignore_empty_summary_on"
 		android:summaryOff="@string/ignore_empty_summary_off"
 		android:defaultValue="true" />
+	<CheckBoxPreference
+		android:key="@string/key_ignore_groups"
+		android:title="@string/ignore_groups"
+		android:summaryOn="@string/ignore_groups_summary_on"
+		android:summaryOff="@string/ignore_groups_summary_off"
+		android:defaultValue="true" />
 	<EditTextPreference
 		android:key="@string/key_ignore_repeat"
 		android:title="@string/ignore_repeat"


### PR DESCRIPTION
While I appreciate ignoring group messages by default, some apps (specifically Signal) do all their text notifications as group notifications, which means they simply don't get read. For people who use Signal as their default SMS client, this ignoring needs to be toggled.