### PR TITLE
Add a quick settings tile to toggle Voice Notify

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,7 @@
 			android:exported="true">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
+				<action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
 				<category android:name="android.intent.category.LAUNCHER" />
 			</intent-filter>
 		</activity>
@@ -49,6 +50,18 @@
 			android:exported="true">
 			<intent-filter>
 				<action android:name="android.service.notification.NotificationListenerService" />
+			</intent-filter>
+		</service>
+		<service
+			android:name=".VoiceNotifyTileService"
+			android:exported="true"
+			android:label="@string/app_name"
+			android:icon="@drawable/widget"
+			android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+			<meta-data android:name="android.service.quicksettings.TOGGLEABLE_TILE"
+				android:value="true" />
+			<intent-filter>
+				<action android:name="android.service.quicksettings.action.QS_TILE" />
 			</intent-filter>
 		</service>
 		<receiver

--- a/app/src/main/java/com/pilot51/voicenotify/VoiceNotifyTileService.kt
+++ b/app/src/main/java/com/pilot51/voicenotify/VoiceNotifyTileService.kt
@@ -1,0 +1,33 @@
+package com.pilot51.voicenotify
+
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import androidx.annotation.RequiresApi
+
+@RequiresApi(Build.VERSION_CODES.N)
+class VoiceNotifyTileService : TileService() {
+    // Called when the tile can be updated
+    override fun onStartListening() {
+        super.onStartListening()
+        updateTile(Service.isSuspended.value)
+    }
+
+    // Called when the user taps on the tile in an active or inactive state.
+    override fun onClick() {
+        super.onClick()
+        val result = Service.toggleSuspend()
+        updateTile(result)
+    }
+
+    private fun updateTile(suspended: Boolean) {
+        val isRunning = Service.isRunning.value
+
+        qsTile.state = when {
+            !isRunning -> Tile.STATE_UNAVAILABLE
+            isRunning && suspended -> Tile.STATE_INACTIVE
+            else -> Tile.STATE_ACTIVE
+        }
+        qsTile.updateTile()
+    }
+}

--- a/app/src/main/java/com/pilot51/voicenotify/VoiceNotifyTileService.kt
+++ b/app/src/main/java/com/pilot51/voicenotify/VoiceNotifyTileService.kt
@@ -16,8 +16,8 @@ class VoiceNotifyTileService : TileService() {
     // Called when the user taps on the tile in an active or inactive state.
     override fun onClick() {
         super.onClick()
-        val result = Service.toggleSuspend()
-        updateTile(result)
+        val isSuspended = Service.toggleSuspend()
+        updateTile(isSuspended)
     }
 
     private fun updateTile(suspended: Boolean) {


### PR DESCRIPTION
Adds a quick settings tile (TileService) that displays the current state of Voice Notify. Clicking on the tile toggles Voice Notify. Long-pressing the tile opens the main screen of Voice Notify.

Disclaimer: I'm very new to Android development and Kotlin, please let me know if there's anything I can do to improve the code.