### PR TITLE
Added regex support

### DIFF
--- a/app/src/main/java/com/pilot51/voicenotify/Constants.kt
+++ b/app/src/main/java/com/pilot51/voicenotify/Constants.kt
@@ -1,0 +1,5 @@
+package com.pilot51.voicenotify
+
+object Constants {
+    const val REGEX_PREFIX = "\$regex:"
+}

--- a/app/src/main/java/com/pilot51/voicenotify/NotificationInfo.kt
+++ b/app/src/main/java/com/pilot51/voicenotify/NotificationInfo.kt
@@ -27,6 +27,7 @@ import java.text.MessageFormat
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.regex.Pattern
+import java.util.regex.PatternSyntaxException
 import kotlin.math.min
 
 /**
@@ -132,11 +133,15 @@ data class NotificationInfo(
 		val ttsTextReplace = if (isComposePreview) null else settings.ttsTextReplace
 		val textReplaceList = PreferencesViewModel.convertTextReplaceStringToList(ttsTextReplace)
 		for (pair in textReplaceList) {
-			val pattern =
+			val pattern = try {
 				if (pair.first.startsWith(Constants.REGEX_PREFIX))
 					Regex(pair.first.removePrefix(Constants.REGEX_PREFIX))
 				else
-					"(?i)${Pattern.quote(pair.first)}".toRegex()
+					null
+			} catch (e: PatternSyntaxException) {
+				e.printStackTrace()
+				null
+			} ?: "(?i)${Pattern.quote(pair.first)}".toRegex()
 
 			ttsMessage = ttsMessage!!.replace(pattern, pair.second)
 		}

--- a/app/src/main/java/com/pilot51/voicenotify/NotificationInfo.kt
+++ b/app/src/main/java/com/pilot51/voicenotify/NotificationInfo.kt
@@ -132,8 +132,13 @@ data class NotificationInfo(
 		val ttsTextReplace = if (isComposePreview) null else settings.ttsTextReplace
 		val textReplaceList = PreferencesViewModel.convertTextReplaceStringToList(ttsTextReplace)
 		for (pair in textReplaceList) {
-			ttsMessage = ttsMessage!!.replace(
-				"(?i)${Pattern.quote(pair.first)}".toRegex(), pair.second)
+			val pattern =
+				if (pair.first.startsWith(Constants.REGEX_PREFIX))
+					Regex(pair.first.removePrefix(Constants.REGEX_PREFIX))
+				else
+					"(?i)${Pattern.quote(pair.first)}".toRegex()
+
+			ttsMessage = ttsMessage!!.replace(pattern, pair.second)
 		}
 		val maxLength = if (isComposePreview) 0 else {
 			settings.ttsMaxLength ?: DEFAULT_MAX_LENGTH

--- a/app/src/main/java/com/pilot51/voicenotify/Service.kt
+++ b/app/src/main/java/com/pilot51/voicenotify/Service.kt
@@ -226,7 +226,8 @@ class Service : NotificationListenerService() {
 				fun containsOrMatchesRegex(it: String): Boolean {
 					return if (it.startsWith(Constants.REGEX_PREFIX))
 						try {
-							Regex(it.removePrefix(Constants.REGEX_PREFIX), RegexOption.IGNORE_CASE)
+							val pattern = it.removePrefix(Constants.REGEX_PREFIX)
+							Regex(pattern, RegexOption.IGNORE_CASE)
 								.containsMatchIn(ttsMsg)
 						} catch (e: PatternSyntaxException) {
 							false

--- a/app/src/main/java/com/pilot51/voicenotify/Service.kt
+++ b/app/src/main/java/com/pilot51/voicenotify/Service.kt
@@ -70,6 +70,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import java.util.*
+import java.util.regex.PatternSyntaxException
 
 class Service : NotificationListenerService() {
 	private val appContext by ::applicationContext
@@ -222,16 +223,28 @@ class Service : NotificationListenerService() {
 				info.ignoreReasons.add(IgnoreReason.EMPTY_MSG)
 			}
 			if (ttsMsg != null) {
+				fun containsOrMatchesRegex(it: String): Boolean {
+					return if (it.startsWith(Constants.REGEX_PREFIX))
+						try {
+							Regex(it.removePrefix(Constants.REGEX_PREFIX), RegexOption.IGNORE_CASE)
+								.containsMatchIn(ttsMsg)
+						} catch (e: PatternSyntaxException) {
+							false
+						}
+					else
+						ttsMsg.contains(it, true)
+				}
+
 				val requireStrings = settings.requireStrings?.split("\n")
 				val stringRequired = requireStrings?.all {
-					it.isNotEmpty() && !ttsMsg.contains(it, true)
+					it.isNotEmpty() && !containsOrMatchesRegex(it)
 				} ?: false
 				if (stringRequired) {
 					info.ignoreReasons.add(IgnoreReason.STRING_REQUIRED)
 				}
 				val ignoreStrings = settings.ignoreStrings?.split("\n")
 				val stringIgnored = ignoreStrings?.any {
-					it.isNotEmpty() && ttsMsg.contains(it, true)
+					it.isNotEmpty() && containsOrMatchesRegex(it)
 				} ?: false
 				if (stringIgnored) {
 					info.ignoreReasons.add(IgnoreReason.STRING_IGNORED)

--- a/app/src/main/java/com/pilot51/voicenotify/Service.kt
+++ b/app/src/main/java/com/pilot51/voicenotify/Service.kt
@@ -251,8 +251,7 @@ class Service : NotificationListenerService() {
 					return if (it.startsWith(Constants.REGEX_PREFIX))
 						try {
 							val pattern = it.removePrefix(Constants.REGEX_PREFIX)
-							Regex(pattern, RegexOption.IGNORE_CASE)
-								.containsMatchIn(ttsMsg)
+							Regex(pattern).containsMatchIn(ttsMsg)
 						} catch (e: PatternSyntaxException) {
 							e.printStackTrace()
 							false

--- a/app/src/main/java/com/pilot51/voicenotify/Service.kt
+++ b/app/src/main/java/com/pilot51/voicenotify/Service.kt
@@ -230,6 +230,7 @@ class Service : NotificationListenerService() {
 							Regex(pattern, RegexOption.IGNORE_CASE)
 								.containsMatchIn(ttsMsg)
 						} catch (e: PatternSyntaxException) {
+							e.printStackTrace()
 							false
 						}
 					else

--- a/app/src/main/java/com/pilot51/voicenotify/TextReplaceDialog.kt
+++ b/app/src/main/java/com/pilot51/voicenotify/TextReplaceDialog.kt
@@ -56,7 +56,19 @@ fun TextReplaceDialog(
 			add(null)
 		}
 	}
-	val onSave = { vm.saveTtsTextReplace(settings, replaceList) }
+	val onSave = {
+		val invalidRegex = replaceList.any { pair ->
+			pair?.first?.startsWith(Constants.REGEX_PREFIX) == true && runCatching {
+				Regex(pair.first.removePrefix(Constants.REGEX_PREFIX))
+			}.isFailure
+		}
+
+		if (invalidRegex) {
+			// Show Toast
+		} else {
+			vm.saveTtsTextReplace(settings, replaceList)
+		}
+	}
 	AlertDialog(
 		onDismissRequest = onDismiss,
 		confirmButton = {

--- a/app/src/main/java/com/pilot51/voicenotify/Utils.kt
+++ b/app/src/main/java/com/pilot51/voicenotify/Utils.kt
@@ -23,6 +23,14 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 
 fun <T> T.isAny(vararg list: T) = list.any { this == it }
 
+/**
+ * @return `false` if [text] is prefixed with [Constants.REGEX_PREFIX]
+ * and the regex format is invalid. `true` if format is valid or not prefixed.
+ */
+fun validateRegexOption(text: String) = !text.startsWith(Constants.REGEX_PREFIX) || runCatching {
+	Regex(text.removePrefix(Constants.REGEX_PREFIX))
+}.isSuccess
+
 val isPreview @Composable get() = LocalInspectionMode.current
 
 @Preview(name = "Dark", uiMode = Configuration.UI_MODE_NIGHT_YES)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,7 +51,7 @@
 	<string name="require_strings_summary">Only speak notifications that contain certain text in the message</string>
 	<string name="ignore_strings">Ignore Text</string>
 	<string name="ignore_strings_summary">Ignore notifications that contain certain text in the message</string>
-	<string name="require_ignore_strings_dialog_msg">This is matched against the message sent to TTS, after TTS Message formatting and Text Replacement, including punctuation.\n\nSeparate individual entries with a new line.\nThe message needs to contain any entry, not all, to be a match.\nCase insensitive.\nTo use regex, type the prefix $regex: and then your regex.\nFor example: $regex:[^xyz].\nRegex is case sensitive.</string>
+	<string name="require_ignore_strings_dialog_msg">This is matched against the message sent to TTS, after TTS Message formatting and Text Replacement, including punctuation.\n\nSeparate individual entries with a new line.\nThe message needs to contain any entry, not all, to be a match.\nCase insensitive.</string>
 	<string name="ignore_empty">Ignore Empty</string>
 	<string name="ignore_empty_summary_on">Notifications without a message will not be spoken</string>
 	<string name="ignore_empty_summary_off">Notifications without a message will be spoken as \"Notification from [app name].\"</string>
@@ -147,6 +147,8 @@
 	<string name="error_browser">Error: Unable to find an installed browser app.</string>
 	<string name="remove_override">Remove override</string>
 	<string name="remove_override_confirm">Remove %1$s override for %2$s?</string>
+	<string name="regex_message">\n\nTo use regex, prefix the text with \"$regex:\". Regex is case sensitive by default.\nFor example, to match a URL (ignoring case):\n$regex:(?i)https?:\\/\\/[^\s]+\n</string>
+	<string name="invalid_regex">Invalid regex</string>
 
 	<!-- AppListScreen -->
 	<string name="close">Close</string>
@@ -167,7 +169,7 @@
 	<string name="tts_message_dialog">#A = App title\n#T = Ticker\n#S = Subtext\n#C = Content title\n#M = Content message\n#I = Content info\n#H = Big content title\n#Y = Big content summary\n#B = Big content text\n#L = Text lines\nCase insensitive\n\nDefault:\n%1$s\n\nOld default (v1.1.0 - v1.3.0):\n#A. #C. #M.\n\nOld default (v1.0.x):\n#A: #T</string>
 	<string name="tts_text_replace">TTS Text Replacement</string>
 	<string name="tts_text_replace_summary">Substitute text to be spoken, such as to fix pronunciation</string>
-	<string name="tts_text_replace_dialog">Substitute text to be spoken, allowing you to customize how Text-To-Speech pronounces words or replace text for any other reason.\n\nText to replace is case insensitive and applies after TTS Message formatting and before emoji removal.\nTo use regex, type the prefix $regex: and then your regex.\nFor example: $regex:[^xyz].\nRegex is case sensitive.</string>
+	<string name="tts_text_replace_dialog">Substitute text to be spoken, allowing you to customize how Text-To-Speech pronounces words or replace text for any other reason.\n\nText to replace is case insensitive and applies after TTS Message formatting and before emoji removal.</string>
 	<string name="text_replace_error_duplicate">Duplicate! Will not be saved.</string>
 	<string name="text_to_replace">Text to replace</string>
 	<string name="replacement_text">Replacement text</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,7 +51,7 @@
 	<string name="require_strings_summary">Only speak notifications that contain certain text in the message</string>
 	<string name="ignore_strings">Ignore Text</string>
 	<string name="ignore_strings_summary">Ignore notifications that contain certain text in the message</string>
-	<string name="require_ignore_strings_dialog_msg">This is matched against the message sent to TTS, after TTS Message formatting and Text Replacement, including punctuation.\n\nSeparate individual entries with a new line.\nThe message needs to contain any entry, not all, to be a match.\nCase insensitive.\nTo use regex, type the prefix $regex: and then your regex.\nFor example: $regex:[^xyz].\nRegex is case-insensitive.</string>
+	<string name="require_ignore_strings_dialog_msg">This is matched against the message sent to TTS, after TTS Message formatting and Text Replacement, including punctuation.\n\nSeparate individual entries with a new line.\nThe message needs to contain any entry, not all, to be a match.\nCase insensitive.\nTo use regex, type the prefix $regex: and then your regex.\nFor example: $regex:[^xyz].\nRegex is case sensitive.</string>
 	<string name="ignore_empty">Ignore Empty</string>
 	<string name="ignore_empty_summary_on">Notifications without a message will not be spoken</string>
 	<string name="ignore_empty_summary_off">Notifications without a message will be spoken as \"Notification from [app name].\"</string>
@@ -167,7 +167,7 @@
 	<string name="tts_message_dialog">#A = App title\n#T = Ticker\n#S = Subtext\n#C = Content title\n#M = Content message\n#I = Content info\n#H = Big content title\n#Y = Big content summary\n#B = Big content text\n#L = Text lines\nCase insensitive\n\nDefault:\n%1$s\n\nOld default (v1.1.0 - v1.3.0):\n#A. #C. #M.\n\nOld default (v1.0.x):\n#A: #T</string>
 	<string name="tts_text_replace">TTS Text Replacement</string>
 	<string name="tts_text_replace_summary">Substitute text to be spoken, such as to fix pronunciation</string>
-	<string name="tts_text_replace_dialog">Substitute text to be spoken, allowing you to customize how Text-To-Speech pronounces words or replace text for any other reason.\n\nText to replace is case insensitive and applies after TTS Message formatting and before emoji removal.\nTo use regex, type the prefix $regex: and then your regex.\nFor example: $regex:[^xyz].\nRegex is case-insensitive.</string>
+	<string name="tts_text_replace_dialog">Substitute text to be spoken, allowing you to customize how Text-To-Speech pronounces words or replace text for any other reason.\n\nText to replace is case insensitive and applies after TTS Message formatting and before emoji removal.\nTo use regex, type the prefix $regex: and then your regex.\nFor example: $regex:[^xyz].\nRegex is case sensitive.</string>
 	<string name="text_replace_error_duplicate">Duplicate! Will not be saved.</string>
 	<string name="text_to_replace">Text to replace</string>
 	<string name="replacement_text">Replacement text</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,7 +51,7 @@
 	<string name="require_strings_summary">Only speak notifications that contain certain text in the message</string>
 	<string name="ignore_strings">Ignore Text</string>
 	<string name="ignore_strings_summary">Ignore notifications that contain certain text in the message</string>
-	<string name="require_ignore_strings_dialog_msg">This is matched against the message sent to TTS, after TTS Message formatting and Text Replacement, including punctuation.\n\nSeparate individual entries with a new line.\nThe message needs to contain any entry, not all, to be a match.\nCase insensitive.</string>
+	<string name="require_ignore_strings_dialog_msg">This is matched against the message sent to TTS, after TTS Message formatting and Text Replacement, including punctuation.\n\nSeparate individual entries with a new line.\nThe message needs to contain any entry, not all, to be a match.\nCase insensitive.\nTo use regex, type the prefix $regex: and then your regex.\nFor example: $regex:[^xyz].\nRegex is case-insensitive.</string>
 	<string name="ignore_empty">Ignore Empty</string>
 	<string name="ignore_empty_summary_on">Notifications without a message will not be spoken</string>
 	<string name="ignore_empty_summary_off">Notifications without a message will be spoken as \"Notification from [app name].\"</string>
@@ -167,7 +167,7 @@
 	<string name="tts_message_dialog">#A = App title\n#T = Ticker\n#S = Subtext\n#C = Content title\n#M = Content message\n#I = Content info\n#H = Big content title\n#Y = Big content summary\n#B = Big content text\n#L = Text lines\nCase insensitive\n\nDefault:\n%1$s\n\nOld default (v1.1.0 - v1.3.0):\n#A. #C. #M.\n\nOld default (v1.0.x):\n#A: #T</string>
 	<string name="tts_text_replace">TTS Text Replacement</string>
 	<string name="tts_text_replace_summary">Substitute text to be spoken, such as to fix pronunciation</string>
-	<string name="tts_text_replace_dialog">Substitute text to be spoken, allowing you to customize how Text-To-Speech pronounces words or replace text for any other reason.\n\nText to replace is case insensitive and applies after the formatting set in TTS Message, including punctuation.</string>
+	<string name="tts_text_replace_dialog">Substitute text to be spoken, allowing you to customize how Text-To-Speech pronounces words or replace text for any other reason.\n\nText to replace is case insensitive and applies after the formatting set in TTS Message, including punctuation.\nTo use regex, type the prefix $regex: and then your regex.\nFor example: $regex:[^xyz].\nRegex is case-insensitive.</string>
 	<string name="text_replace_error_duplicate">Duplicate! Will not be saved.</string>
 	<string name="text_to_replace">Text to replace</string>
 	<string name="replacement_text">Replacement text</string>


### PR DESCRIPTION
Tested pr, quite simple, that adds regex support for the ignore, require, and replace functionalities.

It works  by adding `$regex:` to the start of each string, and will else function as usual.

Might be worth adding some example patterns, maybe to the readme or something. Not a must.

An example pattern to insert the word space between numbers:
`$regex:(?<=\d)\s+(?=\d)` replace with `space`

An example pattern to insert spaces between numbers:
`$regex:(?<=[0-9])(?=[0-9])` replace with ` `

it is also possible to use group references by just typing $1, $2 etc.




