### PR TITLE
Add themed icon for Android 13 and higher

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
 	<background android:drawable="@drawable/ic_launcher_background"/>
 	<foreground android:drawable="@drawable/ic_launcher_foreground"/>
+	<monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
 	<background android:drawable="@drawable/ic_launcher_background"/>
 	<foreground android:drawable="@drawable/ic_launcher_foreground"/>
+	<monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
This small change makes it possible to show the app icon themed when the user activated "Themed Icons" on their home screen in Android 13.

Preview with and without themed icons enabled:
![themed_icons_voicenotify](https://github.com/user-attachments/assets/88c8ab3f-5cea-4434-90aa-16e31f42a3d4)

